### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: perl
+perl:
+  - "5.20"
+addons:
+  - postgresql: "9.3"
+sudo: false
+env:
+  - TEST_DSN='DBI:Pg:dbname=pageboy;user=postgres'
+install:
+  - cpanm --quiet --installdeps --notest ./provision
+before_script:
+  - psql -c 'create database pageboy;' -U postgres
+  - bin/manage deploydb
+script:
+  - bin/manage test

--- a/README.md
+++ b/README.md
@@ -110,11 +110,15 @@ If you need to recreate the database for any reason:
 
 ### Provisioning
 
-    Vagrantfile - file used to automate virtual machine creation on first `vagrant up`
+    Vagrantfile - config to automate virtual machine creation on first `vagrant up`
+
+    .travis.yml - config for Travis testing
 
     provision/
         cpanfile            - all the CPAN modules to load
         minimal-dotfiles/.* - very basic configuration files to start
+
+See https://travis-ci.org/osfameron/pageboy for automated CI builds.
 
 ## Random notes
 

--- a/lib/Pageboy/Management/Cmd/Test.pm
+++ b/lib/Pageboy/Management/Cmd/Test.pm
@@ -51,7 +51,9 @@ sub execute {
             '-r',           # run recursively
             @ARGV,
         );
-        $ap->run;
+        my $result = $ap->run;
+        my $exit = $result ? 0 : 1;
+        exit $exit;
     }
 }
 

--- a/t/lib/Pageboy/Test/Geo.pm
+++ b/t/lib/Pageboy/Test/Geo.pm
@@ -15,8 +15,30 @@ has _ip => (
     writer => 'set_ip',
 );
 
+has lookup => (
+    is => 'ro',
+    traits => ['Hash'],
+    default => sub {
+        +{
+            '130.88.98.239' => 'Manchester', # man.ac.uk
+            '138.253.13.50' => 'Liverpool',  # liv.ac.uk
+            '145.18.12.36'  => 'Amsterdam',  # uva.nl
+        }
+    },
+    handles => {
+        '_get_location_from_ip' => 'get',
+    },
+);
+
 sub get_ip_from_request ($self, $r) {
     return $self->_ip;
+}
+
+sub get_location_from_ip ($self, $r) {
+    my $ip = $self->get_ip_from_request($r)
+        or return;
+
+    return $self->_get_location_from_ip($ip);
 }
 
 1;


### PR DESCRIPTION
NB: as Test::PostgreSQL wraps exit (in order to tear down the
temporary Postgres instance) it traps DESTROY, and consequently
breaks the return code of the test runner (probably a bug.)

Instead, we use Travis's default Pg cluster, and pass TEST_DSN
expicitly to it (which prevents us from spawning Test::PSQL).

Notes:
- perl "5.20" (as apparently 5.22 not enabled yet)
- postgresql: "9.3" (as that's what we have here)
- sudo: false (sets up containerized build)
- env: (pass in the TEST_DSN as explained above)

<!---
@huboard:{"custom_state":"archived"}
-->
